### PR TITLE
feat(azurefunctions): Remove warn for previous failures when in sync

### DIFF
--- a/azurefunctions/azurefunctions/agent_based/azurefunctions.py
+++ b/azurefunctions/azurefunctions/agent_based/azurefunctions.py
@@ -145,7 +145,7 @@ def _check_scheduled_invocations(funcspec, funclogs):
 
     if success_log:
         yield Result(
-            state=State.OK if nfailures == 0 else State.WARN,
+            state=State.OK,
             summary="Schedule in sync",
             details=f"Schedule is in sync with {nfailures} previous failures",
         )


### PR DESCRIPTION
When schedule is in sync, which means that a successful excecution of
a scheduled function is fired after the last schedule, where was a
warning in case of previous failed executions.

As the warning signals just *previous* failures in the check window
(24h), so no action by the function admins can modify the past, but in
fact the expected result (schedule in sync) is already achieved.

So we remove this warning, avoiding to clutter the CheckMK dashboard
with problems that do not exist anymore.